### PR TITLE
Updated StaffCard to display regions correctly

### DIFF
--- a/src/components/admin/StaffCard.vue
+++ b/src/components/admin/StaffCard.vue
@@ -1,22 +1,19 @@
 <template>
   <v-card flat>
-    <v-list two-line subheader>
+    <v-list v-if="!isFindPending" three-line subheader>
       <v-subheader> Active Users </v-subheader>
-      <v-list-tile  v-for="user in listUsers"
+      <v-list-tile  v-for="user in users"
                     :key="user._id"
       >
         <v-list-tile-content>
           <v-list-tile-title>
             {{ `${user.name.first} ${user.name.last}` }}
           </v-list-tile-title>
+          <v-list-tile-sub-title class="text--primary">
+            {{ user.region }}
+          </v-list-tile-sub-title>
           <v-list-tile-sub-title>
             {{ user.email }}
-          </v-list-tile-sub-title>
-        </v-list-tile-content>
-
-        <v-list-tile-content>
-          <v-list-tile-sub-title>
-            {{ user.region }}
           </v-list-tile-sub-title>
         </v-list-tile-content>
 
@@ -65,7 +62,7 @@
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex';
+import { mapGetters, mapActions, mapState } from 'vuex';
 
 export default {
   props: ['primary'],
@@ -79,17 +76,54 @@ export default {
       inviteDialog: false,
     };
   },
-  mounted() {
-    this.findUsers();
+  created() {
+    this.findUsers({
+      query: {
+        $sort: {
+          updatedAt: -1,
+        },
+      },
+    });
+    this.findRegions();
   },
   computed: {
-    ...mapGetters('users', { listUsers: 'list' }),
+    ...mapGetters('users', { findUsersInStore: 'find' }),
+    ...mapGetters('regions', { getRegionInStore: 'get' }),
+    ...mapState('users', { isFindPendingUsers: 'isFindPending' }),
+    ...mapState('regions', { isFindPendingRegions: 'isFindPending' }),
+    isFindPending() {
+      return this.isFindPendingUsers || this.isFindPendingRegions;
+    },
+    users() {
+      const users = this.findUsersInStore({
+        query: {
+          $limit: 5,
+          $sort: {
+            updatedAt: -1,
+          },
+          _id: {
+            // eslint-disable-next-line
+            $ne: this.$store.state.auth.user._id,
+          },
+        },
+      }).data;
+
+      const usersWithRegion = users.map((user) => {
+        if (user.region) {
+          const region = this.getRegionInStore(user.region);
+          return { ...user, region: region.name };
+        }
+        return { ...user, region: 'No region' };
+      });
+      return usersWithRegion;
+    },
     dark() {
       return this.$store.getters['users/current'].darktheme;
     },
   },
   methods: {
     ...mapActions('users', { findUsers: 'find' }),
+    ...mapActions('regions', { findRegions: 'find' }),
   },
 };
 </script>

--- a/src/components/admin/StaffCard.vue
+++ b/src/components/admin/StaffCard.vue
@@ -1,6 +1,6 @@
 <template>
   <v-card flat>
-    <v-list v-if="!isFindPending" three-line subheader>
+    <v-list v-show="!isFindPending" three-line subheader>
       <v-subheader> Active Users </v-subheader>
       <v-list-tile  v-for="user in users"
                     :key="user._id"


### PR DESCRIPTION
Regions are now pulled correctly from the server and can be updated through sockets.
Names of each user's region is now displayed in the staff card.
Closes #55 