### PR TITLE
Cham view regions

### DIFF
--- a/src/components/Region.vue
+++ b/src/components/Region.vue
@@ -1,9 +1,14 @@
 <template>
   <v-layout row wrap>
     <v-flex xs12 md4>
-      <v-card flat>
-        <v-list-item two-line>
-          <h2>Select a Region</h2>
+      <v-card>
+        <v-card-title class="pb-0">
+          <h3 class="headline mb-0"
+            :class="`${primary}--text`">
+            Select a Region
+          </h3>
+        </v-card-title>
+        <v-list>
           <v-list-tile
             v-for="region in allRegions"
             :key="region._id"
@@ -11,34 +16,51 @@
           >
             {{ region.name }}
           </v-list-tile>
-        </v-list-item>
+        </v-list>
       </v-card>
     </v-flex>
-    <v-flex xs12 md8>
-      <v-card flat>
+    <v-flex xs12 md8 v-show="currentlySelectedRegion">
+      <v-card>
+        <v-card-title class="pb-0">
+          {{ !currentlySelectedRegion ? "No region selected" : currentlySelectedRegion.name }}
+        </v-card-title>
         <v-list>
-          <h3>Staff</h3>
-            <v-row xs6 md4 align="stretch" justify="space-around">
-              <h4>Key</h4>
-              <p>Coach <v-icon>mdi-account-tie</v-icon>
-              </p><p>Manager <v-icon>mdi-account-tie-outline</v-icon></p>
-              <p>Admin <v-icon>mdi-account-tie-voice</v-icon></p>
-            </v-row>
+          <v-subheader>Users</v-subheader>
           <v-list-tile v-for="user in users" :key="user._id">
             <v-list-tile-content>
               {{ `${user.name.first} ${user.name.last}` }}
             </v-list-tile-content>
-            <v-icon v-if="user.coach.is">mdi-account-tie </v-icon>
-            <v-icon v-if="user.manager.is">mdi-account-tie-outline </v-icon>
-            <v-icon v-if="user.admin.is">mdi-account-tie-voice </v-icon>
+            <v-tooltip bottom transition="none">
+              <template v-slot:activator="{ on }">
+               <v-icon v-if="user.coach.is" v-on="on">mdi-football-australian </v-icon>
+              </template>
+              <span>Coach</span>
+            </v-tooltip>
+            <v-tooltip bottom transition="none">
+              <template v-slot:activator="{ on }">
+               <v-icon v-if="user.manager.is" v-on="on">mdi-account-tie </v-icon>
+              </template>
+              <span>Manager</span>
+            </v-tooltip>
+            <v-tooltip bottom transition="none">
+              <template v-slot:activator="{ on }">
+               <v-icon v-if="user.admin.is" v-on="on">mdi-shield-account </v-icon>
+              </template>
+              <span>Admin</span>
+            </v-tooltip>
           </v-list-tile>
         </v-list>
         <v-list>
-          <br />
-          <h3>Schools</h3>
+          <v-subheader>Schools</v-subheader>
           <v-list-tile v-for="school in schools" :key="school._id">
-            {{ `${school.name}` }}
-            <v-list-content>{{school.phoneNumber}}</v-list-content> <br>
+            <v-list-tile-content>
+              {{ school.name }}
+            </v-list-tile-content>
+            <v-list-tile-action>
+              <v-subheader>
+                {{ school.phoneNumber }}
+              </v-subheader>
+            </v-list-tile-action>
           </v-list-tile>
         </v-list>
       </v-card>
@@ -54,52 +76,59 @@ export default {
   data() {
     return {
       allRegions: [],
-      currentlySelectedRegion: [],
+      currentlySelectedRegion: null,
       users: [],
       schools: [],
+      dark: false,
     };
   },
   computed: {
     ...mapGetters('regions', { listRegions: 'list' }),
+    primary() {
+      return this.$store.state.auth.user.darktheme ? 'darkPrimary' : 'lightPrimary';
+    },
   },
   methods: {
     ...mapActions('regions', { findRegions: 'find' }),
     ...mapActions('users', { findUsers: 'find' }),
     ...mapActions('schools', { findSchools: 'find' }),
+    populateUsers(region) {
+      return this.findUsers({
+        query: {
+          _id: {
+            $in: region.users,
+          },
+        },
+      });
+    },
+    populateSchools(region) {
+      return this.findSchools({
+        query: {
+          _id: {
+            $in: region.schools,
+          },
+        },
+      });
+    },
     /* This method fetches the respective region given the id input in the click method */
-    getRegion(id) {
-      const selectedRegion = this.listRegions.find(regions => regions._id === id);
+    async getRegion(id) {
+      const selectedRegion = this.allRegions.find(region => region._id === id);
+      const usersPromise = this.populateUsers(selectedRegion);
+      const schoolsPromise = this.populateSchools(selectedRegion);
+      const [{ data: usersData }, { data: schoolsData }] = await Promise.all(
+        [usersPromise,
+          schoolsPromise],
+      );
+      this.users = usersData;
+      this.schools = schoolsData;
       this.currentlySelectedRegion = selectedRegion;
-      this.findUsers({
-        query: {
-          _id: {
-            $in: this.currentlySelectedRegion.users,
-          },
-        },
-      }).then((response) => {
-        this.users = response.data;
-      });
-      this.findSchools({
-        query: {
-          _id: {
-            $in: this.currentlySelectedRegion.schools,
-          },
-        },
-      }).then((response) => {
-        this.schools = response.data;
-      });
     },
   },
   /* intialling fetching all the regions as a list when the page is created. Once
   the regions have been loaded, then the user can individually click on them */
-  created() {
-    this.findRegions({
-      query: {},
-    }).then((response) => {
-      this.allRegions = response.data;
-    });
+  async mounted() {
+    const { data: regionData } = await this.findRegions();
+    this.allRegions = regionData;
   },
 };
 </script>
-
-<style></style>

--- a/src/components/Region.vue
+++ b/src/components/Region.vue
@@ -3,8 +3,7 @@
     <v-flex xs12 md4>
       <v-card>
         <v-card-title class="pb-0">
-          <h3 class="headline mb-0"
-            :class="`${primary}--text`">
+          <h3 class="headline mb-0" :class="`${primary}--text`">
             Select a Region
           </h3>
         </v-card-title>
@@ -32,19 +31,19 @@
             </v-list-tile-content>
             <v-tooltip bottom transition="none">
               <template v-slot:activator="{ on }">
-               <v-icon v-if="user.coach.is" v-on="on">mdi-football-australian </v-icon>
+                <v-icon v-if="user.coach.is" v-on="on">mdi-football-australian </v-icon>
               </template>
               <span>Coach</span>
             </v-tooltip>
             <v-tooltip bottom transition="none">
               <template v-slot:activator="{ on }">
-               <v-icon v-if="user.manager.is" v-on="on">mdi-account-tie </v-icon>
+                <v-icon v-if="user.manager.is" v-on="on">mdi-account-tie </v-icon>
               </template>
               <span>Manager</span>
             </v-tooltip>
             <v-tooltip bottom transition="none">
               <template v-slot:activator="{ on }">
-               <v-icon v-if="user.admin.is" v-on="on">mdi-shield-account </v-icon>
+                <v-icon v-if="user.admin.is" v-on="on">mdi-shield-account </v-icon>
               </template>
               <span>Admin</span>
             </v-tooltip>

--- a/src/components/Region.vue
+++ b/src/components/Region.vue
@@ -1,34 +1,64 @@
 <template>
-  <v-card>
-    <v-layout row wrap>
-      <v-flex xs12 md4>
-        <v-list v-for="region in oneRegion" :key="region">
-          <v-list-tile>Region name: <b>{{ `${region.name}` }}</b></v-list-tile>
-          <v-list-item-content>
-            <b>Schools</b>
-          <ul v-for="school in oneSchools" :key="school">
-            <li>{{school.name}}</li>
-          </ul>
-          <b>Users</b>
-          <ul v-for="user in oneUsers" :key='user'>
-            <li>{{user.name.first}},{{user.name.last}}</li>
-          </ul>
-          </v-list-item-content>
+  <v-layout row wrap>
+    <v-flex xs12 md4>
+      <v-card flat>
+        <v-list-item two-line>
+          <h2>Select a Region</h2>
+          <v-list-tile
+            v-for="region in allRegions"
+            :key="region._id"
+            @click="getRegion(region._id)"
+          >
+            {{ region.name }}
+          </v-list-tile>
+        </v-list-item>
+      </v-card>
+    </v-flex>
+    <v-flex xs12 md8>
+      <v-card flat>
+        <v-list>
+          <h3>Staff</h3>
+            <v-row xs6 md4 align="stretch" justify="space-around">
+              <h4>Key</h4>
+              <p>Coach <v-icon>mdi-account-tie</v-icon>
+              </p><p>Manager <v-icon>mdi-account-tie-outline</v-icon></p>
+              <p>Admin <v-icon>mdi-account-tie-voice</v-icon></p>
+            </v-row>
+          <v-list-tile v-for="user in users" :key="user._id">
+            <v-list-tile-content>
+              {{ `${user.name.first} ${user.name.last}` }}
+            </v-list-tile-content>
+            <v-icon v-if="user.coach.is">mdi-account-tie </v-icon>
+            <v-icon v-if="user.manager.is">mdi-account-tie-outline </v-icon>
+            <v-icon v-if="user.admin.is">mdi-account-tie-voice </v-icon>
+          </v-list-tile>
         </v-list>
-      </v-flex>
-    </v-layout>
-  </v-card>
+        <v-list>
+          <br />
+          <h3>Schools</h3>
+          <v-list-tile v-for="school in schools" :key="school._id">
+            {{ `${school.name}` }}
+            <v-list-content>{{school.phoneNumber}}</v-list-content> <br>
+          </v-list-tile>
+        </v-list>
+      </v-card>
+    </v-flex>
+  </v-layout>
 </template>
 
 <script>
+/* eslint no-underscore-dangle: ["error", { "allow": ["_id"] }] */
 import { mapGetters, mapActions } from 'vuex';
 
 export default {
-  data: () => ({
-    oneRegion: {},
-    oneSchools: {},
-    oneUsers: {},
-  }),
+  data() {
+    return {
+      allRegions: [],
+      currentlySelectedRegion: [],
+      users: [],
+      schools: [],
+    };
+  },
   computed: {
     ...mapGetters('regions', { listRegions: 'list' }),
   },
@@ -36,40 +66,40 @@ export default {
     ...mapActions('regions', { findRegions: 'find' }),
     ...mapActions('users', { findUsers: 'find' }),
     ...mapActions('schools', { findSchools: 'find' }),
+    /* This method fetches the respective region given the id input in the click method */
+    getRegion(id) {
+      const selectedRegion = this.listRegions.find(regions => regions._id === id);
+      this.currentlySelectedRegion = selectedRegion;
+      this.findUsers({
+        query: {
+          _id: {
+            $in: this.currentlySelectedRegion.users,
+          },
+        },
+      }).then((response) => {
+        this.users = response.data;
+      });
+      this.findSchools({
+        query: {
+          _id: {
+            $in: this.currentlySelectedRegion.schools,
+          },
+        },
+      }).then((response) => {
+        this.schools = response.data;
+      });
+    },
   },
+  /* intialling fetching all the regions as a list when the page is created. Once
+  the regions have been loaded, then the user can individually click on them */
   created() {
     this.findRegions({
-      query: {
-        $limit: 1,
-      },
+      query: {},
     }).then((response) => {
-      this.oneRegion = response.data;
-    });
-    this.findSchools({
-      query: {
-        _id: {
-          $in: ['5f019ce2f0cce90a929ce235', '5f019ce2f0cce90a929ce236', '5f019ce2f0cce90a929ce238'],
-        },
-      },
-    }).then((response) => {
-      this.oneSchools = response.data;
-    });
-    this.findUsers({
-      query: {
-        _id: {
-          $in: ['5f019d01f0cce90a929ce244', '5f019d04f0cce90a929ce248', '5f019d04f0cce90a929ce245',
-            '5f019d04f0cce90a929ce246', '5f019d04f0cce90a929ce247', '5f019d04f0cce90a929ce249',
-            '5f019d04f0cce90a929ce24a'],
-        },
-      },
-    }).then((response) => {
-      this.oneUsers = response.data;
+      this.allRegions = response.data;
     });
   },
 };
 </script>
-<style scoped>
-ul{
-list-style: disc;
-}
-</style>
+
+<style></style>

--- a/src/components/Region.vue
+++ b/src/components/Region.vue
@@ -1,0 +1,30 @@
+<template>
+<v-layout row wrap>
+  <v-card>
+    <v-card-title>
+      Test
+    </v-card-title>
+    <v-list>
+      <v-list-tile avatar @click.native="regionSelected = true">
+        helllo
+      </v-list-tile>
+    </v-list>
+  </v-card>
+  <v-navigation-drawer
+      v-model="regionSelected"
+      absolute
+      right
+      width="1000px"
+    >
+      <v-card>Hi</v-card>
+    </v-navigation-drawer>
+    </v-layout>
+</template>
+
+<script>
+export default {
+  data: () => ({
+    regionSelected: false,
+  }),
+};
+</script>

--- a/src/components/Region.vue
+++ b/src/components/Region.vue
@@ -1,30 +1,75 @@
 <template>
-<v-layout row wrap>
   <v-card>
-    <v-card-title>
-      Test
-    </v-card-title>
-    <v-list>
-      <v-list-tile avatar @click.native="regionSelected = true">
-        helllo
-      </v-list-tile>
-    </v-list>
-  </v-card>
-  <v-navigation-drawer
-      v-model="regionSelected"
-      absolute
-      right
-      width="1000px"
-    >
-      <v-card>Hi</v-card>
-    </v-navigation-drawer>
+    <v-layout row wrap>
+      <v-flex xs12 md4>
+        <v-list v-for="region in oneRegion" :key="region">
+          <v-list-tile>Region name: <b>{{ `${region.name}` }}</b></v-list-tile>
+          <v-list-item-content>
+            <b>Schools</b>
+          <ul v-for="school in oneSchools" :key="school">
+            <li>{{school.name}}</li>
+          </ul>
+          <b>Users</b>
+          <ul v-for="user in oneUsers" :key='user'>
+            <li>{{user.name.first}},{{user.name.last}}</li>
+          </ul>
+          </v-list-item-content>
+        </v-list>
+      </v-flex>
     </v-layout>
+  </v-card>
 </template>
 
 <script>
+import { mapGetters, mapActions } from 'vuex';
+
 export default {
   data: () => ({
-    regionSelected: false,
+    oneRegion: {},
+    oneSchools: {},
+    oneUsers: {},
   }),
+  computed: {
+    ...mapGetters('regions', { listRegions: 'list' }),
+  },
+  methods: {
+    ...mapActions('regions', { findRegions: 'find' }),
+    ...mapActions('users', { findUsers: 'find' }),
+    ...mapActions('schools', { findSchools: 'find' }),
+  },
+  created() {
+    this.findRegions({
+      query: {
+        $limit: 1,
+      },
+    }).then((response) => {
+      this.oneRegion = response.data;
+    });
+    this.findSchools({
+      query: {
+        _id: {
+          $in: ['5f019ce2f0cce90a929ce235', '5f019ce2f0cce90a929ce236', '5f019ce2f0cce90a929ce238'],
+        },
+      },
+    }).then((response) => {
+      this.oneSchools = response.data;
+    });
+    this.findUsers({
+      query: {
+        _id: {
+          $in: ['5f019d01f0cce90a929ce244', '5f019d04f0cce90a929ce248', '5f019d04f0cce90a929ce245',
+            '5f019d04f0cce90a929ce246', '5f019d04f0cce90a929ce247', '5f019d04f0cce90a929ce249',
+            '5f019d04f0cce90a929ce24a'],
+        },
+      },
+    }).then((response) => {
+      this.oneUsers = response.data;
+    });
+  },
 };
 </script>
+<style scoped>
+ul{
+list-style: disc;
+}
+</style>

--- a/src/components/admin/Index.vue
+++ b/src/components/admin/Index.vue
@@ -1,95 +1,14 @@
 <template>
-  <v-layout fill-height row>
-    <v-flex xs12 sm6 md4
-            v-for="i in columns" :key="i"
-    >
-      <v-layout row wrap class="pa-0">
-        <v-flex xs12
-                :class="{'pa-2': i === 1}"
-                v-for="(card, index) in cards" :key="index"
-                v-show="index%columns === (i-1)"
-        >
-          <component :is="card" :primary="primary"/>
-        </v-flex>
-      </v-layout>
-    </v-flex>
-  </v-layout>
+  <router-view :dark="dark" />
 </template>
 
 <script>
-import spinner from '@/other/Spinner.vue';
-
 export default {
   title: 'Admin Dashboard',
-  components: {
-    'staff-card': () => ({
-      component: import('./StaffCard.vue'),
-      loading: spinner,
-    }),
-    'region-card': () => ({
-      component: import('./RegionCard.vue'),
-      loading: spinner,
-    }),
-    'program-card': () => ({
-      component: import('./ProgramCard.vue'),
-      loading: spinner,
-    }),
-    'activity-card': () => ({
-      component: import('./ActivityCard.vue'),
-      loading: spinner,
-    }),
-    'session-card': () => ({
-      component: import('./SessionCard.vue'),
-      loading: spinner,
-    }),
-    'student-card': () => ({
-      component: import('./StudentCard.vue'),
-      loading: spinner,
-    }),
-    'school-card': () => ({
-      component: import('./SchoolCard.vue'),
-      loading: spinner,
-    }),
-  },
   props: {
     dark: {
       type: Boolean,
       default: false,
-    },
-  },
-  data() {
-    return {
-      cards: [
-        'staff-card',
-        'region-card',
-        'program-card',
-        'activity-card',
-        'session-card',
-        'student-card',
-        'school-card',
-      ],
-      width: 0,
-    };
-  },
-  created() {
-    window.addEventListener('resize', this.handleResize);
-    this.handleResize();
-  },
-  destroyed() {
-    window.removeEventListener('resize', this.handleResize);
-  },
-  computed: {
-    primary() {
-      return this.dark ? 'darkPrimary' : 'lightPrimary';
-    },
-    columns() {
-      // eslint-disable-next-line
-      return this.width < 600 ? 1 : this.width < 960 ? 2 : 3;
-    },
-  },
-  methods: {
-    handleResize() {
-      this.width = window.innerWidth;
     },
   },
 };

--- a/src/components/admin/RegionCard.vue
+++ b/src/components/admin/RegionCard.vue
@@ -22,7 +22,7 @@
     </v-card-title>
 
     <v-card-actions class="pa-0">
-      <v-btn  flat round v-on:click="$router.push('/admin/Region')">View All</v-btn>
+      <v-btn  flat round @click="$router.push('/admin/Region')">View All</v-btn>
       <v-btn  flat round @click="regionDialog = true">
         Create New
       </v-btn>

--- a/src/components/admin/RegionCard.vue
+++ b/src/components/admin/RegionCard.vue
@@ -22,12 +22,8 @@
     </v-card-title>
 
     <v-card-actions class="pa-0">
-      <v-btn  flat round @click="allRegionDialog = true">View All</v-btn>
-      <all-regions v-model="allRegionDialog" v-bind="{ dark }"/>
-      <v-btn  flat
-              round
-              @click="regionDialog = true"
-      >
+      <v-btn  flat round v-on:click="$router.push('/admin/Region')">View All</v-btn>
+      <v-btn  flat round @click="regionDialog = true">
         Create New
       </v-btn>
       <new-region v-model="regionDialog" v-bind="{ dark }" />
@@ -45,14 +41,10 @@ export default {
     'new-region': () => ({
       component: import('./modals/NewRegion.vue'),
     }),
-    'all-regions': () => ({
-      component: import('./modals/ViewAllRegions.vue'),
-    }),
   },
   data() {
     return {
       regionDialog: false,
-      allRegionDialog: false,
     };
   },
   computed: {

--- a/src/components/admin/RegionCard.vue
+++ b/src/components/admin/RegionCard.vue
@@ -22,11 +22,8 @@
     </v-card-title>
 
     <v-card-actions class="pa-0">
-      <v-btn  flat
-              round
-      >
-        View All
-      </v-btn>
+      <v-btn  flat round @click="allRegionDialog = true">View All</v-btn>
+      <all-regions v-model="allRegionDialog" v-bind="{ dark }"/>
       <v-btn  flat
               round
               @click="regionDialog = true"
@@ -48,10 +45,14 @@ export default {
     'new-region': () => ({
       component: import('./modals/NewRegion.vue'),
     }),
+    'all-regions': () => ({
+      component: import('./modals/ViewAllRegions.vue'),
+    }),
   },
   data() {
     return {
       regionDialog: false,
+      allRegionDialog: false,
     };
   },
   computed: {

--- a/src/components/admin/dashboard.vue
+++ b/src/components/admin/dashboard.vue
@@ -1,0 +1,96 @@
+<template>
+  <v-layout fill-height row>
+    <v-flex xs12 sm6 md4
+            v-for="i in columns" :key="i"
+    >
+      <v-layout row wrap class="pa-0">
+        <v-flex xs12
+                :class="{'pa-2': i === 1}"
+                v-for="(card, index) in cards" :key="index"
+                v-show="index%columns === (i-1)"
+        >
+          <component :is="card" :primary="primary"/>
+        </v-flex>
+      </v-layout>
+    </v-flex>
+  </v-layout>
+</template>
+
+<script>
+import spinner from '@/other/Spinner.vue';
+
+export default {
+  title: 'Admin Dashboard',
+  components: {
+    'staff-card': () => ({
+      component: import('./StaffCard.vue'),
+      loading: spinner,
+    }),
+    'region-card': () => ({
+      component: import('./RegionCard.vue'),
+      loading: spinner,
+    }),
+    'program-card': () => ({
+      component: import('./ProgramCard.vue'),
+      loading: spinner,
+    }),
+    'activity-card': () => ({
+      component: import('./ActivityCard.vue'),
+      loading: spinner,
+    }),
+    'session-card': () => ({
+      component: import('./SessionCard.vue'),
+      loading: spinner,
+    }),
+    'student-card': () => ({
+      component: import('./StudentCard.vue'),
+      loading: spinner,
+    }),
+    'school-card': () => ({
+      component: import('./SchoolCard.vue'),
+      loading: spinner,
+    }),
+  },
+  props: {
+    dark: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  data() {
+    return {
+      cards: [
+        'staff-card',
+        'region-card',
+        'program-card',
+        'activity-card',
+        'session-card',
+        'student-card',
+        'school-card',
+      ],
+      width: 0,
+    };
+  },
+  created() {
+    window.addEventListener('resize', this.handleResize);
+    this.handleResize();
+  },
+  destroyed() {
+    window.removeEventListener('resize', this.handleResize);
+  },
+  computed: {
+    primary() {
+      return this.dark ? 'darkPrimary' : 'lightPrimary';
+    },
+    columns() {
+      // eslint-disable-next-line
+      return this.width < 600 ? 1 : this.width < 960 ? 2 : 3;
+    },
+  },
+  methods: {
+    handleResize() {
+      this.width = window.innerWidth;
+    },
+  },
+};
+</script>

--- a/src/components/admin/modals/ViewAllRegions.vue
+++ b/src/components/admin/modals/ViewAllRegions.vue
@@ -1,0 +1,68 @@
+<template>
+  <v-dialog
+    scrollable
+    max-width="520"
+    v-model="showDialog"
+    transition="dialog-transition"
+    :fullscreen="$vuetify.breakpoint.xsOnly"
+  >
+    <v-card flat tile>
+      <v-toolbar flat>
+        <h1 class="headline">All Regions</h1>
+        <v-spacer />
+        <v-btn flat icon @click="$emit('input')">
+          <v-icon> mdi-close </v-icon>
+        </v-btn>
+      </v-toolbar>
+      <v-card-text>
+      <v-list rounded v-for="region in listRegions" :key="region">
+        <v-list-item-group>
+          <v-list-item>
+            <v-list-item-icon>
+              <v-icon>mdi-map-marker-multiple</v-icon>
+            </v-list-item-icon>
+            <v-list-item-content>
+              <v-list-item-title>{{region.name}}</v-list-item-title>
+              <ul>
+                  <li>State: {{region.state}}</li>
+                  <li>Number of students: Object.keys({{region.users}}).length</li>
+              </ul>
+            </v-list-item-content>
+          </v-list-item>
+        </v-list-item-group>
+      </v-list>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import { mapGetters } from 'vuex';
+
+export default {
+  name: 'ViewAllRegions',
+  props: ['value', 'dark'],
+  computed: {
+    showDialog: {
+      get() {
+        return this.value;
+      },
+    },
+    ...mapGetters('regions', { listRegions: 'list' }),
+    ...mapGetters('regions', { allTheRegions: 'list' }),
+  },
+};
+</script>
+<style>
+.v-card {
+  border-top-left-radius: 0 !important;
+  border-top-right-radius: 0 !important;
+}
+.list {
+  padding: calc(0.5 * var(--thiccness)) var(--thiccness);
+}
+
+ul {
+  list-style-type: none;
+}
+</style>

--- a/src/components/admin/modals/ViewAllRegions.vue
+++ b/src/components/admin/modals/ViewAllRegions.vue
@@ -15,25 +15,14 @@
         </v-btn>
       </v-toolbar>
       <v-card-text>
-        <v-list rounded v-for="region in listRegions" :key="region">
-          <v-list-item-group>
-            <v-list-item>
-              <v-list-item-icon>
-                <v-icon>mdi-map-marker-multiple</v-icon>
-              </v-list-item-icon>
-              <v-list-item-content>
-                <v-list-item-title>{{ region.name }}</v-list-item-title>
-                <ul>
-                  <li><b>State:</b> {{ region.state }}</li>
-                  <span v-for="(x, index) in region.users" :key="index">
-                    <span v-if="index === Object.keys(region.users).length - 1">
-                      <b>Number of users:</b> {{ index+1 }}
-                    </span>
-                  </span>
-                </ul>
-              </v-list-item-content>
-            </v-list-item>
-          </v-list-item-group>
+        <v-list two-line>
+          <template v-for="region in listRegions">
+            <v-list-tile :key="region">
+              <v-list-tile-content>
+                <v-list-tile-title>{{ `${region.name}, ${region.state }` }}</v-list-tile-title>
+              </v-list-tile-content>
+            </v-list-tile>
+          </template>
         </v-list>
       </v-card-text>
     </v-card>
@@ -55,6 +44,9 @@ export default {
     showDialog: {
       get() {
         return this.value;
+      },
+      set(value) {
+        this.$emit('input', value);
       },
     },
     ...mapGetters('regions', { listRegions: 'list' }),

--- a/src/components/admin/modals/ViewAllRegions.vue
+++ b/src/components/admin/modals/ViewAllRegions.vue
@@ -24,8 +24,12 @@
             <v-list-item-content>
               <v-list-item-title>{{region.name}}</v-list-item-title>
               <ul>
-                  <li>State: {{region.state}}</li>
-                  <li>Number of students: Object.keys({{region.users}}).length</li>
+                  <li><b>State:</b> {{region.state}}</li>
+                  <span v-for="(x,index) in region.users" :key="index">
+                      <span v-if="index === Object.keys(region.users).length - 1">
+                          <b>Number of students:</b> {{index}}
+                      </span>
+                  </span>
               </ul>
             </v-list-item-content>
           </v-list-item>
@@ -42,6 +46,11 @@ import { mapGetters } from 'vuex';
 export default {
   name: 'ViewAllRegions',
   props: ['value', 'dark'],
+  data() {
+    return {
+      numOfStudents: [],
+    };
+  },
   computed: {
     showDialog: {
       get() {
@@ -49,7 +58,6 @@ export default {
       },
     },
     ...mapGetters('regions', { listRegions: 'list' }),
-    ...mapGetters('regions', { allTheRegions: 'list' }),
   },
 };
 </script>

--- a/src/components/admin/modals/ViewAllRegions.vue
+++ b/src/components/admin/modals/ViewAllRegions.vue
@@ -15,26 +15,26 @@
         </v-btn>
       </v-toolbar>
       <v-card-text>
-      <v-list rounded v-for="region in listRegions" :key="region">
-        <v-list-item-group>
-          <v-list-item>
-            <v-list-item-icon>
-              <v-icon>mdi-map-marker-multiple</v-icon>
-            </v-list-item-icon>
-            <v-list-item-content>
-              <v-list-item-title>{{region.name}}</v-list-item-title>
-              <ul>
-                  <li><b>State:</b> {{region.state}}</li>
-                  <span v-for="(x,index) in region.users" :key="index">
-                      <span v-if="index === Object.keys(region.users).length - 1">
-                          <b>Number of students:</b> {{index}}
-                      </span>
+        <v-list rounded v-for="region in listRegions" :key="region">
+          <v-list-item-group>
+            <v-list-item>
+              <v-list-item-icon>
+                <v-icon>mdi-map-marker-multiple</v-icon>
+              </v-list-item-icon>
+              <v-list-item-content>
+                <v-list-item-title>{{ region.name }}</v-list-item-title>
+                <ul>
+                  <li><b>State:</b> {{ region.state }}</li>
+                  <span v-for="(x, index) in region.users" :key="index">
+                    <span v-if="index === Object.keys(region.users).length - 1">
+                      <b>Number of users:</b> {{ index+1 }}
+                    </span>
                   </span>
-              </ul>
-            </v-list-item-content>
-          </v-list-item>
-        </v-list-item-group>
-      </v-list>
+                </ul>
+              </v-list-item-content>
+            </v-list-item>
+          </v-list-item-group>
+        </v-list>
       </v-card-text>
     </v-card>
   </v-dialog>

--- a/src/router.js
+++ b/src/router.js
@@ -10,8 +10,11 @@ const Dashboard = () => import(/* webpackChunkName: "dashboard" */ './views/Dash
 const Error = () => import(/* webpackChunkName: "404page" */ './views/404.vue');
 
 const Admin = () => import(/* webpackChunkName: "admin" */ './components/admin/Index.vue');
+const AdminDash = () => import(/* webpackChunkName: "admin" */ './components/admin/dashboard.vue');
 const Manager = () => import(/* webpackChunkName: "manager" */ './components/manager/Index.vue');
 const Coach = () => import(/* webpackChunkName: "coach" */ './components/coach/Index.vue');
+
+const Region = () => import(/* webpackChunkName: "region" */ './components/Region.vue');
 
 Vue.use(Router);
 
@@ -64,6 +67,18 @@ const router = new Router({
           name: 'admin',
           component: Admin,
           meta: { permission: 'admin' },
+          children: [
+            {
+              path: '/',
+              name: 'admin-dash',
+              component: AdminDash,
+            },
+            {
+              path: 'region',
+              name: 'region',
+              component: Region,
+            },
+          ],
         },
         {
           path: 'manager',


### PR DESCRIPTION
Added the ability to see each region along with its corresponding state and number of users assigned.
Each region instance consists of a name, state, and a subarray of how many users are assigned to it. 
I simply fetched the data from the region's store and displayed them in a new vue modal which will pop up when the "view all" button is clicked in the region card.